### PR TITLE
Check AssemblyRoot Before Moving Player

### DIFF
--- a/src/init.luau
+++ b/src/init.luau
@@ -335,6 +335,7 @@ function AnchoredPlatformPlayerMovement.EnableClientReplication(self: AnchoredPl
             local Humanoid = Character:FindFirstChildOfClass("Humanoid") :: Humanoid
             local HumanoidRootPart = Character:FindFirstChild("HumanoidRootPart") :: BasePart
             if not Humanoid or not HumanoidRootPart or Humanoid.Health <= 0 then continue end
+            if HumanoidRootPart.AssemblyRootPart ~= HumanoidRootPart then continue end --The AssemblyRootPart is checked in case the player is attached to something else (like the platform through a seat).
             local ExtrapolationTime = math.min((tick() - CurrentPlatform.LastUpdateTime), MAX_EXTRAPOLATION_SECONDS)
             local ExtrapolatedAnglularVelocity = ExtrapolationTime * CharacterAngularVelocity
             HumanoidRootPart.CFrame = CFrame.new(ExtrapolationTime * CharacterVelocity) * AssemblyRoot.CFrame * CharacterOffset * CFrame.Angles(ExtrapolatedAnglularVelocity.X, ExtrapolatedAnglularVelocity.Y, ExtrapolatedAnglularVelocity.Z)


### PR DESCRIPTION
Players that have a significant enough delay can send platform data while still appearing to be in a seat, allowing those players to move the assembly. This check makes sure players aren't moved unless they are their own assembly root (i.e. not welded to anything anchored).