### PR TITLE
Fixed code example typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local AnchoredPlatformPlayerMovement = require(...)
 
 AnchoredPlatformPlayerMovement:EnableLocalCharacterUpdates() --Sets up moving the local player (required).
-AnchoredPlatformPlayerMovement:EnableServerReplication() --Sets up replication and moving other players (optional).
+AnchoredPlatformPlayerMovement:EnableClientReplication() --Sets up replication and moving other players (optional).
 AnchoredPlatformPlayerMovement:EnableDebugView(Enum.KeyCode.F2) --Sets up a debug view toggle (optional).
 ```
 
@@ -34,7 +34,7 @@ local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local AnchoredPlatformPlayerMovement = require(...)
 
 AnchoredPlatformPlayerMovement:EnableLocalCharacterUpdates()
-                              :EnableServerReplication()
+                              :EnableClientReplication()
                               :EnableDebugView(Enum.KeyCode.F2)
 ```
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ any parts are needed.
 On the client, at least `EnableLocalCharacterUpdates` must be
 called in the module to move the local player. `EnableDebugView`
 can be optionally called to add a keybind for the debug view,
-and `EnableServerReplication` to enable replication (server setup
+and `EnableClientReplication` to enable replication (server setup
 required).
 
 ```luau


### PR DESCRIPTION
Client example in readme tries to run "EnableServerReplication", this function does what it says on the tin, meaning it would only work on servers.

This PR makes replaces "EnableServerReplication" in the client part of the code example to "EnableClientReplication"